### PR TITLE
Try to load C extension under the lib directory at first

### DIFF
--- a/lib/go_version/wrapper.rb
+++ b/lib/go_version/wrapper.rb
@@ -4,7 +4,11 @@ module GoVersion
   module Wrapper
     extend FFI::Library
 
-    ffi_lib File.join(File.expand_path(__dir__), "../../ext/go-version/go_version.bundle")
+    begin
+      ffi_lib File.join(File.expand_path(__dir__), "../../lib/go-version/go_version.bundle")
+    rescue LoadError
+      ffi_lib File.join(File.expand_path(__dir__), "../../ext/go-version/go_version.bundle")
+    end
     attach_function :Check, [:string, :string], :bool
   end
 end


### PR DESCRIPTION
Ruby 3.2 with RubyGems 3.4 will cleanup `ext` directory after installation. We should call `go_version` from `lib` directory.